### PR TITLE
change `write.REYN()` so compressed files are written with `readr::write_csv()`

### DIFF
--- a/eddy4r.york/DESCRIPTION
+++ b/eddy4r.york/DESCRIPTION
@@ -18,6 +18,7 @@ Imports:
     lubridate,
     magrittr,
     purrr,
+    readr,
     rlang,
     stats,
     stringr,

--- a/eddy4r.york/R/wrap.lag.R
+++ b/eddy4r.york/R/wrap.lag.R
@@ -54,8 +54,8 @@ wrap.lag = function(eddy.data,
                          dat = purrr::pluck(.x, "corr")
 
                          tibble::tibble(date = eddy.data$date[1],
-                                        lag = dat$lag,
-                                        acf = dat$acf,
+                                        lag = dat$lag[ , 1, 1],
+                                        acf = dat$acf[ , 1, 1],
                                         name = .y)
                        }
   )

--- a/eddy4r.york/R/wrap.towr.R
+++ b/eddy4r.york/R/wrap.towr.R
@@ -164,7 +164,7 @@ wrap.towr = function(paraMain,
                                  aggregationDuration = para$aggregationDuration,
                                  freq = para$freq)},
       error = function(e){
-        eddy4R.york::log_message(wrap_tower_log, "error", "Handel Missing Values", det_avg$periodStartDate[i], det_avg$periodEndDate[i], e)
+        eddy4R.york::log_message(wrap_tower_log, "error", "Handle Missing Values", det_avg$periodStartDate[i], det_avg$periodEndDate[i], e)
         return(NULL)
       })
 

--- a/eddy4r.york/R/write.REYN.R
+++ b/eddy4r.york/R/write.REYN.R
@@ -67,9 +67,9 @@ write.REYN = function(REYN,
     files$REYN[[i]]$unixTimeMin = unixTimeMin
 
     if(files$compress[i]){
-      utils::write.csv(files$REYN[[i]],
-                       file = files$fileOut[i],
-                       row.names = F)
+      # readr::write_csv automatically compresses the data when the extension is .gz (in this case .csv.gz)
+      readr::write_csv(files$REYN[[i]],
+                       file = files$fileOut[i])
     }else{
       if(!file.exists(files$fileOut[i])){
         utils::write.table(files$REYN[[i]],


### PR DESCRIPTION
Also exposed an issue where  ACF was being constructed with list columns, which didn't play well with `write_csv()` so adjusted `wrap.lag()` to clean this up